### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/lib/logstash/inputs/generator.rb
+++ b/lib/logstash/inputs/generator.rb
@@ -62,7 +62,7 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
     end
     @lines = [@message] if @lines.nil?
 
-    while !finished? && (@count <= 0 || number < @count)
+    while !stop? && (@count <= 0 || number < @count)
       @lines.each do |line|
         @codec.decode(line.clone) do |event|
           decorate(event)
@@ -92,6 +92,5 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
         queue << event
       end
     end
-    finished
   end # def teardown
 end # class LogStash::Inputs::Generator

--- a/spec/inputs/generator_spec.rb
+++ b/spec/inputs/generator_spec.rb
@@ -1,7 +1,11 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/generator"
 
-describe "inputs/generator" do
+describe LogStash::Inputs::Generator do
+
+  it_behaves_like "an interruptible input plugin" do
+    let(:config) { { } }
+  end
 
   it "should generate configured message" do
     conf = <<-CONFIG
@@ -37,7 +41,7 @@ describe "inputs/generator" do
     saved_stdin = $stdin
     stdin_mock = StringIO.new
     $stdin = stdin_mock
-    stdin_mock.should_receive(:readline).once.and_return("bar")
+    expect(stdin_mock).to receive(:readline).once.and_return("bar")
 
     events = input(conf) do |pipeline, queue|
       2.times.map{queue.pop}


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3815

resolves #10 
