### PR TITLE
Docs: minor typo

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -79,7 +79,7 @@ Example:
       }
     }
 
-The above will emit `line 1` then `line 2` then `line`, then `line 1`, etc...
+The above will emit `line 1` then `line 2` then `line 3`, then `line 1`, etc...
 
 [id="plugins-{type}s-{plugin}-message"]
 ===== `message` 


### PR DESCRIPTION
Fixed small typo in the explanation of what the example emits.
