### PR TITLE
Feat: adjust fields for ECS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+  - Feat: adjusted fields for ECS compatibility [#22](https://github.com/logstash-plugins/logstash-input-generator/pull/22) 
+  - Fix: codec flushing when closing input
+
 ## 3.0.6
   - Docs: Set the default_codec doc attribute.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.0
-  - Feat: adjusted fields for ECS compatibility [#22](https://github.com/logstash-plugins/logstash-input-generator/pull/22) 
+  - Feat: adjusted fields for ECS compatibility [#22](https://github.com/logstash-plugins/logstash-input-generator/pull/22)
+  - Fix: do not override the host field if it's present in the generator line (after decoding) 
   - Fix: codec flushing when closing input
 
 ## 3.0.6

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -27,6 +27,19 @@ The general intention of this is to test performance of plugins.
 
 An event is generated first
 
+[id="plugins-{type}s-{plugin}-ecs"]
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin uses different field names depending on whether {ecs-ref}[ECS-compatibility]
+in enabled (see also <<plugins-{type}s-{plugin}-ecs_compatibility>>).
+
+|========
+| ECS Disabled | ECS v1 | Description
+
+| `host`  | `[host][name]` | The name of the {ls} host that processed the event
+| `sequence` | `[event][sequence]` | The sequence number for the generated event
+|========
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Generator Input Configuration Options
 
@@ -36,6 +49,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-count>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-lines>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-message>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-threads>> |<<number,number>>|No
@@ -55,6 +69,43 @@ input plugins.
 Set how many messages should be generated.
 
 The default, `0`, means generate an unlimited number of events.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: uses backwards compatible field names e.g. `[host]`
+    ** `v1`, `v8`: uses fields that are compatible with ECS e.g. `[host][name]`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs>> for detailed information.
+
+Example output:
+
+**Sample output: ECS enabled**
+[source,ruby]
+-----
+{
+    "message" => "Hello world!",
+    "event" => {
+        "sequence" => 0
+    },
+    "host" => {
+        "name" => "the-machine"
+    }
+}
+-----
+
+**Sample output: ECS disabled**
+[source,ruby]
+-----
+{
+    "message" => "Hello world!",
+    "sequence" => 0,
+    "host" => "the-machine"
+}
+-----
 
 [id="plugins-{type}s-{plugin}-lines"]
 ===== `lines` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,7 +34,7 @@ This plugin uses different field names depending on whether {ecs-ref}[ECS-compat
 in enabled (see also <<plugins-{type}s-{plugin}-ecs_compatibility>>).
 
 |========
-| ECS Disabled | ECS v1 | Description
+| ECS Disabled | ECS v1, v8 | Description
 
 | `host`  | `[host][name]` | The name of the {ls} host that processed the event
 | `sequence` | `[event][sequence]` | The sequence number for the generated event

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -75,13 +75,12 @@ The default, `0`, means generate an unlimited number of events.
 
   * Value type is <<string,string>>
   * Supported values are:
-    ** `disabled`: uses backwards compatible field names e.g. `[host]`
-    ** `v1`, `v8`: uses fields that are compatible with ECS e.g. `[host][name]`
+    ** `disabled`: uses backwards compatible field names, such as `[host]`
+    ** `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 See <<plugins-{type}s-{plugin}-ecs>> for detailed information.
 
-Example output:
 
 **Sample output: ECS enabled**
 [source,ruby]

--- a/lib/logstash/inputs/generator.rb
+++ b/lib/logstash/inputs/generator.rb
@@ -53,7 +53,7 @@ class LogStash::Inputs::Generator < LogStash::Inputs::Threadable
 
   public
   def register
-    @host = Socket.gethostname
+    @host = Socket.gethostname.freeze
     @count = Array(@count).first
 
     @host_name_field = ecs_select[disabled: 'host', v1: '[host][name]']

--- a/logstash-input-generator.gemspec
+++ b/logstash-input-generator.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-generator'
-  s.version         = '3.0.6'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Generates random log events for test purposes"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-input-generator.gemspec
+++ b/logstash-input-generator.gemspec
@@ -25,6 +25,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'insist'
 end
 

--- a/spec/inputs/generator_spec.rb
+++ b/spec/inputs/generator_spec.rb
@@ -1,6 +1,7 @@
 require "logstash/devutils/rspec/spec_helper"
-require "insist"
 require "logstash/devutils/rspec/shared_examples"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
+
 require "logstash/inputs/generator"
 
 describe LogStash::Inputs::Generator do
@@ -25,11 +26,11 @@ describe LogStash::Inputs::Generator do
 
     events = events.sort_by {|e| e.get("sequence") }
 
-    insist { events[0].get("sequence") } == 0
-    insist { events[0].get("message") } == "foo"
+    expect( events[0].get("sequence") ).to eql 0
+    expect( events[0].get("message") ).to eql 'foo'
 
-    insist { events[1].get("sequence") } == 1
-    insist { events[1].get("message") } == "foo"
+    expect( events[1].get("sequence") ).to eql 1
+    expect( events[1].get("message") ).to eql 'foo'
   end
 
   it "should generate message from stdin" do
@@ -42,9 +43,7 @@ describe LogStash::Inputs::Generator do
       }
     CONFIG
 
-    saved_stdin = $stdin
-    stdin_mock = StringIO.new
-    $stdin = stdin_mock
+    $stdin = stdin_mock = StringIO.new
     expect(stdin_mock).to receive(:readline).once.and_return("bar")
 
     events = input(conf) do |pipeline, queue|
@@ -53,12 +52,13 @@ describe LogStash::Inputs::Generator do
 
     events = events.sort_by {|e| e.get("sequence") }
 
-    insist { events[0].get("sequence") } == 0
-    insist { events[0].get("message") } == "bar"
+    expect( events[0].get("sequence") ).to eql 0
+    expect( events[0].get("message") ).to eql 'bar'
 
-    insist { events[1].get("sequence") } == 1
-    insist { events[1].get("message") } == "bar"
-
-    $stdin = saved_stdin
+    expect( events[1].get("sequence") ).to eql 1
+    expect( events[1].get("message") ).to eql 'bar'
   end
+
+  after { $stdin = STDIN }
+
 end

--- a/spec/inputs/generator_spec.rb
+++ b/spec/inputs/generator_spec.rb
@@ -4,61 +4,71 @@ require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
 require "logstash/inputs/generator"
 
-describe LogStash::Inputs::Generator do
+describe LogStash::Inputs::Generator, :ecs_compatibility_support do
 
   it_behaves_like "an interruptible input plugin" do
     let(:config) { { } }
   end
 
-  it "should generate configured message" do
-    conf = <<-CONFIG
-      input {
-        generator {
-          count => 2
-          message => "foo"
-        }
-      }
-    CONFIG
+  ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
 
-    events = input(conf) do |pipeline, queue|
-      2.times.map{queue.pop}
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
     end
 
-    events = events.sort_by {|e| e.get("sequence") }
-
-    expect( events[0].get("sequence") ).to eql 0
-    expect( events[0].get("message") ).to eql 'foo'
-
-    expect( events[1].get("sequence") ).to eql 1
-    expect( events[1].get("message") ).to eql 'foo'
-  end
-
-  it "should generate message from stdin" do
-    conf = <<-CONFIG
-      input {
-        generator {
-          count => 2
-          message => "stdin"
-        }
-      }
-    CONFIG
-
-    $stdin = stdin_mock = StringIO.new
-    expect(stdin_mock).to receive(:readline).once.and_return("bar")
-
-    events = input(conf) do |pipeline, queue|
-      2.times.map{queue.pop}
+    let(:sequence_field) do
+      ecs_select.active_mode == :disabled ? 'sequence' : '[event][sequence]'
     end
 
-    events = events.sort_by {|e| e.get("sequence") }
+    it "should generate configured message" do
+      conf = <<-CONFIG
+        input {
+          generator {
+            count => 2
+            message => "foo"
+          }
+        }
+      CONFIG
 
-    expect( events[0].get("sequence") ).to eql 0
-    expect( events[0].get("message") ).to eql 'bar'
+      events = input(conf) do |pipeline, queue|
+        2.times.map { queue.pop }
+      end
 
-    expect( events[1].get("sequence") ).to eql 1
-    expect( events[1].get("message") ).to eql 'bar'
+      events.each { |event| expect( event.get("message") ).to eql 'foo' }
+
+      expect( events.first.get(sequence_field) ).to be_an Integer
+
+      events = events.sort_by { |e| e.get(sequence_field) }
+      expect( events[0].get(sequence_field) ).to eql 0
+      expect( events[1].get(sequence_field) ).to eql 1
+    end
+
+    it "should generate message from stdin" do
+      conf = <<-CONFIG
+        input {
+          generator {
+            count => 2
+            message => "stdin"
+          }
+        }
+      CONFIG
+
+      $stdin = stdin_mock = StringIO.new
+      expect(stdin_mock).to receive(:readline).once.and_return("bar")
+
+      events = input(conf) do |pipeline, queue|
+        2.times.map { queue.pop }
+      end
+
+      events.each { |event| expect( event.get("message") ).to eql 'bar' }
+
+      events = events.sort_by {|e| e.get(sequence_field) }
+      expect( events[0].get(sequence_field) ).to eql 0
+      expect( events[1].get(sequence_field) ).to eql 1
+    end
+
+    after { $stdin = STDIN }
+
   end
-
-  after { $stdin = STDIN }
 
 end


### PR DESCRIPTION
Previously plugin was setting the top level `sequence` and `host` fields for every event (these aren't ECS compliant).

Also we're no longer override the host field if it's present in the generator line (after decoding by the codec).